### PR TITLE
Adding necessary files for HACS inclusion

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,8 @@
+{
+    "name": "Yahoo Finance",
+    "domains": [
+        "sensor"
+    ],
+    "iot_class": "cloud_poll",
+    "render_readme": true
+}


### PR DESCRIPTION
Added a simple file for HACS inclusion. 

I think you will also need to add a PR to be added to the default search. 

But otherwise, people can just add a custom repo to use this. 
https://hacs.xyz/docs/publish/include